### PR TITLE
Fixed bug when blocks are lists or scalar

### DIFF
--- a/scipy/sparse/construct.py
+++ b/scipy/sparse/construct.py
@@ -728,7 +728,7 @@ def block_diag(mats, format=None, dtype=None):
            [0, 0, 0, 7]])
 
     """
-    if all([mat.shape == mats[-1].shape for mat in mats[:-1]] ):
+    if all( hasattr(mat,'shape')and(mat.shape == mats[-1].shape) for mat in mats ): 
         return _block_diag(mats,format=format,dtype=dtype)
         
     nmat = len(mats)


### PR DESCRIPTION
Deferred to the classic behavior when blocks have no "shape" attribute
Following @pv advice and switched from comprehensive list to generator 
Line 731 relies on Python lazy evaluation of x and y
